### PR TITLE
Add TBD for git-secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Diff So Fancy](#diff-so-fancy)
 - [Git Stats](#git-stats)
 - [Git Secret](#git-secret)
+- [Git Secrets](#git-secrets)
 - [git-fixup](#git-fixup)
 - [git-recent](#git-recent)
 - [git-fiddle](#git-fiddle)
@@ -1559,6 +1560,13 @@ gpg: gpg-agent is not available in this session
 File `hideme.txt' exists. Overwrite? (y/N) y
 done. all 1 files are revealed.
 ```
+
+
+## [git-secrets](https://github.com/awslabs/git-secrets)
+
+> Prevents you from committing passwords and other sensitive information to a git repository.
+
+TBD
 
 
 ## [git-fixup](https://github.com/keis/git-fixup)


### PR DESCRIPTION
I discovered [git-secrets](https://github.com/awslabs/git-secrets) and I find it really awesome.

I added a short description as it is common at GitHub projects. I know that currently, there is no short description for each entry, but I would really love to see a one-liner for each tool.

The commands are hard to reproduce. Maybe just reformatting https://github.com/awslabs/git-secrets#example-walkthrough to the format of this list would be enough?

Nevertheless, I put `TBD` to enable a quick merge to advertise this helpful tool to others. The TBD will be solved by volunteers (refs https://github.com/stevemao/awesome-git-addons/issues/11).