### PR TITLE
Fix image for git-interactive-rebase-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1618,7 +1618,7 @@ $ git recent
 $ git rebase -i master
 ```
 
-![git-interactive-rebase-tool screenshot](https://raw.githubusercontent.com/MitMaro/git-interactive-rebase-tool/master/git-interactive-tool.gif)
+![git-interactive-rebase-tool screenshot](https://raw.githubusercontent.com/MitMaro/git-interactive-rebase-tool/master/docs/assets/images/git-interactive-rebase-demo.gif)
 
 ## [git-fiddle](https://github.com/felixSchl/git-fiddle)
 


### PR DESCRIPTION
Tool recently went 1.0, with a ui overhall, therefore the main .gif was changed.

This fixes said `404` -> `200`!