### PR TITLE
Add git-spend to sum up the `/spend …` directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [git-jump](#git-jump)
 - [git-project](#git-project)
 - [git-branchcut](#git-branchcut)
+- [git-spend](#git-spend)
 
 
 ## [git-extras](https://github.com/tj/git-extras)
@@ -1927,6 +1928,23 @@ Switched to branch 'main'
 Deleted branch bugfix/test (was e2afad6).
 Deleted branch too-old-branch (was 1d3f82d).
 ```
+
+## [git-spend](https://github.com/Goutte/git-spend)
+
+Collect and sum the `/spend <duration>` directives found in commit messages.
+
+```
+$ git spend sum
+3 weeks 2 days 1 hour 37 minutes
+```
+
+### Filter by author, range, and more
+
+```
+$ git spend sum --author stevemao --author antoine@goutenoir.com --since tags/v1.0.0
+1 week 3 hours
+```
+
 
 ## License
 


### PR DESCRIPTION
> I am the author of this addon, so I'm biased at to whether it's awesome or not.   I enjoy it, though.

https://github.com/Goutte/git-spend

I've found useful to track my time in commits, even if I'm not worrying too much about precision. The `/spend 2h30` is supported by Gitlab and Gitea in issues, but I had no tool to sum them up per project.

I can now do a `git spend sum --hours` and get a rough estimation of the total work I've put in projects.

You can try it out with the repo `git-spend` itself, which I actually use as fixture in the acceptance tests.

/spend 30m