### PR TITLE
Add check to make sure all links are up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Validate that links are up
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4  # Required for urlsup
+
+      # This step writes the files with URLs to the env variable $FILES_TO_CHECK to be used for the later step
+      - name: Find files with links
+        shell: bash
+        run: |
+          echo 'FILES_TO_CHECK<<EOF' >> $GITHUB_ENV
+
+          # --- This is where we define what files to check ---
+
+          # $GITHUB_WORKSPACE is where our files live
+          # Ignore dirs and only include markdown files
+
+          files_to_check="README.md"
+
+          echo $files_to_check >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Validate that links are up
+        uses: simeg/urlsup-action@v1.0.0
+        with:
+          # Pass the files and any additional arguments to urlsup
+          args: ${{ env.FILES_TO_CHECK }} --threads 10 --allow 429


### PR DESCRIPTION
With this change Github Action will run with every new commit to check that all links in the README.md file answer with a 200 OK. If they don't, they are logged and the workflow fails.

I tried it on my fork and it found 13 dead links in the repo: https://github.com/simeg/awesome-git-addons/actions/runs/16660137099/job/47155080917?pr=1